### PR TITLE
fix spell mistake of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ O-CNN is built upon the [Caffe](https://github.com/BVLC/caffe) framework and it 
 
 `NOTE`: Compared with the original code used in the experiments of our paper, the code in this repository is refactored for the readability and maintainability, with the sacrifice of speed (it is about 10% slower, but it is more memory-efficient). If you want to try the original code or do some speed comparisons with our `O-CNN`, feel free to drop me an email, we can share the original code with you.
 
-`NOTE`: To build the code on the Ubuntu 16.04, you should first manually install the `glog` and `gflag` by using the following command: `sudo apt-get install libgflags libgoodgle-glog-dev`, and then add the following line `set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=c++11")` in the `Line 60` of the `CMakeLists.txt` file.
+`NOTE`: To build the code on the Ubuntu 16.04, you should first manually install the `glog` and `gflag` by using the following command: `sudo apt-get install libgflags libgoogle-glog-dev`, and then add the following line `set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=c++11")` in the `Line 60` of the `CMakeLists.txt` file.
 
 ### Octree input for O-CNN
 Our O-CNN takes the octree representation of 3D objects as input.  The efficient octree data structure is described in our paper. For convenience, we provide a reference implementation to convert the point cloud with oriented normal to our octree format. The code is contained in the directory `octree`, along with the Microsoft Visual studio 2015 solution file, which can be built to obtain the executable file `octree.exe`. 


### PR DESCRIPTION
README.md, line 35 libgoodgle-glog-dev =>  libgoogle-glog-dev (issues #13 )