### PR TITLE
Add some arguments to octree.exe

### DIFF
--- a/caffe/examples/ao-cnn/dataset.py
+++ b/caffe/examples/ao-cnn/dataset.py
@@ -66,7 +66,7 @@ for i in range(0, len(category)):
   # print(
   subprocess.check_call(
     [octree, '--filenames', filename_list, '--output_path', path_octree, 
-     # '--adp_depth', '4', '--depth', '7']
+     '--adp_depth', '4', '--depth', '7',
     '--adaptive', '1', '--th_distance', '2', '--th_normal', '0.1', 
     '--node_dis', '1', '--split_label', '1']
   )


### PR DESCRIPTION
The original command generates octree data with depth=6 (may be the default setting), while the network is designed to load data with depth=7. So it's necessary to add some arguments to set the depth of the octree.